### PR TITLE
Add support for parsing expression from text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Binary Expression Tree [![wercker status](https://app.wercker.com/status/3627f2113c06b84a316c4d3ab59b414c/s/master "wercker status")](https://app.wercker.com/project/byKey/3627f2113c06b84a316c4d3ab59b414c) [![Code Climate](https://codeclimate.com/repos/57ee74cb0cee2109cb001a8d/badges/df8b36b023b964ac23ca/gpa.svg)](https://codeclimate.com/repos/57ee74cb0cee2109cb001a8d/feed)
+# Binary Expression Tree
+
+[![godoc reference](https://godoc.org/github.com/alexkappa/exp?status.svg)](https://godoc.org/github.com/alexkappa/exp) [![wercker status](https://app.wercker.com/status/3627f2113c06b84a316c4d3ab59b414c/s/master "wercker status")](https://app.wercker.com/project/byKey/3627f2113c06b84a316c4d3ab59b414c) [![Code Climate](https://codeclimate.com/repos/57ee74cb0cee2109cb001a8d/badges/df8b36b023b964ac23ca/gpa.svg)](https://codeclimate.com/repos/57ee74cb0cee2109cb001a8d/feed)
 
 Package exp implements a binary expression tree which can be used to evaluate
 arbitrary binary expressions. You can use this package to build your own
@@ -7,19 +9,27 @@ expressions however a few expressions are provided out of the box.
 ## Installation
 
 ```
-$ go get github.com/alexkappa/exp
+$ go get github.com/alexkappa/exp/...
 ```
 
 ## Usage
 
 ```
-conjunction := And(True, True, True)
-disjunction := Or(True, False)
-negation := Not(False)
+import "github.com/alexkappa/exp"
 
-complex := Or(And(conjunction, disjunction), negation)
+fmt.Printf("%t\n", exp.Or(exp.And(exp.True, exp.Or(exp.True, exp.False)), exp.Not(exp.False)).Eval(nil)) // true
+```
 
-fmt.Printf("%t\n", complex.Eval(p)) // true
+It is also possible to use text to describe expressions.
+
+```
+import (
+	"github.com/alexkappa/exp"
+	"github.com/alexkappa/exp/parse"
+)
+
+exp, _ := parse.Parse(`(foo >= 100.00)`)
+exp.Eval(exp.Map{"foo": "150.00"}) // true
 ```
 
 ## Documentation

--- a/exp.go
+++ b/exp.go
@@ -3,6 +3,13 @@
 // expressions however a few expressions are provided out of the box.
 package exp
 
+import (
+	"errors"
+	"strconv"
+
+	"github.com/alexkappa/exp/parse"
+)
+
 // The Exp interface represents a tree node. There are several implementations
 // of the interface in this package, but one may define custom Exp's as long as
 // they implement the Eval function.
@@ -23,6 +30,231 @@ type Map map[string]string
 // Get returns the value pointed to by key.
 func (m Map) Get(key string) string {
 	return m[key]
+}
+
+func Parse(s string) (Exp, error) {
+	t, err := parse.Parse(s)
+	if err != nil {
+		return nil, err
+	}
+	return visit(t)
+}
+
+func visit(t parse.Tree) (Exp, error) {
+	token := t.Value()
+	switch token.Type {
+	case parse.T_BOOLEAN:
+		switch token.Value {
+		case "true":
+			return True, nil
+		case "false":
+			return False, nil
+		}
+	case parse.T_LOGICAL_AND:
+		l, err := visit(t.Left())
+		if err != nil {
+			return nil, err
+		}
+		r, err := visit(t.Right())
+		if err != nil {
+			return nil, err
+		}
+		return And(l, r), nil
+	case parse.T_LOGICAL_OR:
+		l, err := visit(t.Left())
+		if err != nil {
+			return nil, err
+		}
+		r, err := visit(t.Right())
+		if err != nil {
+			return nil, err
+		}
+		return Or(l, r), nil
+	case parse.T_IS_EQUAL:
+		var (
+			k, v string
+			f    float64
+			l    = t.Left()
+			r    = t.Right()
+		)
+		switch l.Value().Type {
+		case parse.T_IDENTIFIER:
+			k = l.Value().Value
+		case parse.T_STRING:
+			v = l.Value().Value
+		case parse.T_NUMBER:
+			var err error
+			f, err = strconv.ParseFloat(l.Value().Value, 10)
+			if err != nil {
+				return nil, err
+			}
+		}
+		switch r.Value().Type {
+		case parse.T_IDENTIFIER:
+			k = r.Value().Value
+		case parse.T_STRING:
+			v = r.Value().Value
+		case parse.T_NUMBER:
+			var err error
+			f, err = strconv.ParseFloat(r.Value().Value, 10)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if v == "" {
+			return Equal(k, f), nil
+		}
+		return Match(k, v), nil
+	case parse.T_IS_NOT_EQUAL:
+		var (
+			k, v string
+			f    float64
+			l    = t.Left()
+			r    = t.Right()
+		)
+		switch l.Value().Type {
+		case parse.T_IDENTIFIER:
+			k = l.Value().Value
+		case parse.T_STRING:
+			v = l.Value().Value
+		case parse.T_NUMBER:
+			var err error
+			f, err = strconv.ParseFloat(l.Value().Value, 10)
+			if err != nil {
+				return nil, err
+			}
+		}
+		switch r.Value().Type {
+		case parse.T_IDENTIFIER:
+			k = r.Value().Value
+		case parse.T_STRING:
+			v = r.Value().Value
+		case parse.T_NUMBER:
+			var err error
+			f, err = strconv.ParseFloat(r.Value().Value, 10)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if v == "" {
+			return NotEqual(k, f), nil
+		}
+		return Not(Match(k, v)), nil
+	case parse.T_IS_GREATER:
+		var (
+			k string
+			v float64
+			l = t.Left()
+			r = t.Right()
+		)
+		switch l.Value().Type {
+		case parse.T_IDENTIFIER:
+			k = l.Value().Value
+		case parse.T_NUMBER:
+			var err error
+			v, err = strconv.ParseFloat(l.Value().Value, 10)
+			if err != nil {
+				return nil, err
+			}
+		}
+		switch r.Value().Type {
+		case parse.T_IDENTIFIER:
+			k = r.Value().Value
+		case parse.T_NUMBER:
+			var err error
+			v, err = strconv.ParseFloat(r.Value().Value, 10)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return GreaterThan(k, v), nil
+	case parse.T_IS_GREATER_OR_EQUAL:
+		var (
+			k string
+			v float64
+			l = t.Left()
+			r = t.Right()
+		)
+		switch l.Value().Type {
+		case parse.T_IDENTIFIER:
+			k = l.Value().Value
+		case parse.T_NUMBER:
+			var err error
+			v, err = strconv.ParseFloat(l.Value().Value, 10)
+			if err != nil {
+				return nil, err
+			}
+		}
+		switch r.Value().Type {
+		case parse.T_IDENTIFIER:
+			k = r.Value().Value
+		case parse.T_NUMBER:
+			var err error
+			v, err = strconv.ParseFloat(r.Value().Value, 10)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return GreaterOrEqual(k, v), nil
+	case parse.T_IS_SMALLER:
+		var (
+			k string
+			v float64
+			l = t.Left()
+			r = t.Right()
+		)
+		switch l.Value().Type {
+		case parse.T_IDENTIFIER:
+			k = l.Value().Value
+		case parse.T_NUMBER:
+			var err error
+			v, err = strconv.ParseFloat(l.Value().Value, 10)
+			if err != nil {
+				return nil, err
+			}
+		}
+		switch r.Value().Type {
+		case parse.T_IDENTIFIER:
+			k = r.Value().Value
+		case parse.T_NUMBER:
+			var err error
+			v, err = strconv.ParseFloat(r.Value().Value, 10)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return LessThan(k, v), nil
+	case parse.T_IS_SMALLER_OR_EQUAL:
+		var (
+			k string
+			v float64
+			l = t.Left()
+			r = t.Right()
+		)
+		switch l.Value().Type {
+		case parse.T_IDENTIFIER:
+			k = l.Value().Value
+		case parse.T_NUMBER:
+			var err error
+			v, err = strconv.ParseFloat(l.Value().Value, 10)
+			if err != nil {
+				return nil, err
+			}
+		}
+		switch r.Value().Type {
+		case parse.T_IDENTIFIER:
+			k = r.Value().Value
+		case parse.T_NUMBER:
+			var err error
+			v, err = strconv.ParseFloat(r.Value().Value, 10)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return LessOrEqual(k, v), nil
+	}
+
+	return nil, errors.New("invalid expression")
 }
 
 // And

--- a/exp_test.go
+++ b/exp_test.go
@@ -24,3 +24,28 @@ func TestExp(t *testing.T) {
 		}
 	}
 }
+
+func TestParse(t *testing.T) {
+	m := Map{
+		"foo": "124",
+		"bar": "x",
+		"b-z": "z",
+	}
+	for _, s := range []string{
+		`(foo == 124)`,
+		`(foo >= 123)`,
+		`(foo < 456)`,
+		`((foo > 200) || (bar == "x"))`,
+		`((foo > 100) && (bar == "x"))`,
+		`('b-z' == "z")`,
+	} {
+		exp, err := Parse(s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !exp.Eval(m) {
+			t.Error("unexpected output")
+		}
+		t.Logf("%s", exp)
+	}
+}

--- a/parse/ast.go
+++ b/parse/ast.go
@@ -1,0 +1,79 @@
+package parse
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+type Tree interface {
+	Left() Tree
+	Right() Tree
+	Value() token
+}
+
+type tree struct {
+	value token
+	left  *tree
+	right *tree
+}
+
+func (t *tree) Value() token {
+	return t.value
+}
+
+func (t *tree) Left() Tree {
+	return t.left
+}
+
+func (t *tree) Right() Tree {
+	return t.right
+}
+
+func (t *tree) String() string {
+	var left, right string
+	if t.left != nil {
+		left = t.left.String()
+	}
+	if t.right != nil {
+		right = t.right.String()
+	}
+	return fmt.Sprintf("[%s %s %s]", left, t.value, right)
+}
+
+func newTree() *tree {
+	return &tree{}
+}
+
+type stack struct {
+	s []*tree
+	sync.Mutex
+}
+
+func newStack() *stack {
+	return &stack{
+		s: make([]*tree, 0),
+	}
+}
+
+func (s *stack) push(t *tree) {
+	s.Lock()
+	defer s.Unlock()
+
+	s.s = append(s.s, t)
+}
+
+func (s *stack) pop() (*tree, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	l := len(s.s)
+	if l == 0 {
+		return nil, errors.New("empty stack")
+	}
+
+	res := s.s[l-1]
+	s.s = s.s[:l-1]
+
+	return res, nil
+}

--- a/parse/ast_test.go
+++ b/parse/ast_test.go
@@ -1,0 +1,24 @@
+package parse
+
+import "testing"
+
+func TestTree(t *testing.T) {
+	tree := newTree()
+	node := tree
+
+	node.value = token{Value: "0"}
+
+	node.left = newTree()
+	node.left.value = token{Value: "l1"}
+	node.right = newTree()
+	node.right.value = token{Value: "r1"}
+
+	node = node.left
+
+	node.left = newTree()
+	node.left.value = token{Value: "l2"}
+	node.right = newTree()
+	node.right.value = token{Value: "r2"}
+
+	t.Logf("%s", tree)
+}

--- a/parse/lex.go
+++ b/parse/lex.go
@@ -1,0 +1,396 @@
+// Copyright (c) 2016 Alex Kalyvitis
+// Portions Copyright (c) 2011 The Go Authors
+
+package parse
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// <expression> ::= <term> { <or> <term> }
+//
+// <term>       ::= <factor> { <and> <factor> }
+//
+// <factor>     ::= <comparison>
+//               |  <not> <factor>
+//               |  (<expression>)
+//
+// <comparison> ::= <identifier> <operator> <constant>
+//
+// <operator>   ::= <eq>
+//               |  <gt>
+//               |  <gte>
+//               |  <lt>
+//               |  <lte>
+//
+// <or>         ::= '||'
+// <and>        ::= '&&'
+// <not>        ::= '!'
+//
+// <eq>         ::= '=='
+// <gt>         ::= '>'
+// <gte>        ::= '=>'
+// <lt>         ::= '<'
+// <lte>        ::= '<='
+
+// token represents a token or text string returned from the scanner.
+type token struct {
+	Type  tokenType
+	Value string
+	line  int
+	col   int
+}
+
+// String satisfies the fmt.Stringer interface making it easier to print tokens.
+func (i token) String() string {
+	return fmt.Sprintf("%s:%q", i.Type, i.Value)
+}
+
+// tokenType identifies the type of lex tokens.
+type tokenType int
+
+const (
+	T_ERR tokenType = iota
+	T_EOF
+
+	T_IDENTIFIER
+
+	T_NUMBER
+	T_STRING
+
+	T_LOGICAL_AND
+	T_LOGICAL_OR
+	T_LOGICAL_NOT
+
+	T_LEFT_PAREN
+	T_RIGHT_PAREN
+
+	T_IS_EQUAL
+	T_IS_NOT_EQUAL
+	T_IS_GREATER
+	T_IS_GREATER_OR_EQUAL
+	T_IS_SMALLER
+	T_IS_SMALLER_OR_EQUAL
+)
+
+var tokenName = map[tokenType]string{
+	T_ERR:                 "T_ERR",
+	T_EOF:                 "T_EOF",
+	T_IDENTIFIER:          "T_IDENTIFIER",
+	T_NUMBER:              "T_NUMBER",
+	T_STRING:              "T_STRING",
+	T_LOGICAL_AND:         "T_LOGICAL_AND",
+	T_LOGICAL_OR:          "T_LOGICAL_OR",
+	T_LOGICAL_NOT:         "T_LOGICAL_NOT",
+	T_LEFT_PAREN:          "T_LEFT_PAREN",
+	T_RIGHT_PAREN:         "T_RIGHT_PAREN",
+	T_IS_EQUAL:            "T_IS_EQUAL",
+	T_IS_NOT_EQUAL:        "T_IS_NOT_EQUAL",
+	T_IS_GREATER:          "T_IS_GREATER",
+	T_IS_GREATER_OR_EQUAL: "T_IS_GREATER_OR_EQUAL",
+	T_IS_SMALLER:          "T_IS_SMALLER",
+	T_IS_SMALLER_OR_EQUAL: "T_IS_SMALLER_OR_EQUAL",
+}
+
+// String satisfies the fmt.Stringer interface making it easier to print tokens.
+func (i tokenType) String() string {
+	s := tokenName[i]
+	if s == "" {
+		return fmt.Sprintf("t_unknown_%d", int(i))
+	}
+	return s
+}
+
+const eof = -1
+
+// stateFn represents the state of the scanner as a function that returns the
+// next state.
+type stateFn func(*lexer) stateFn
+
+// lexer holds the state of the scanner.
+type lexer struct {
+	name   string     // the name of the input; used only for error reports.
+	input  string     // the string being scanned.
+	state  stateFn    // the next lexing function to enter.
+	pos    int        // current position in the input.
+	start  int        // start position of this token.
+	width  int        // width of last rune read from input.
+	tokens chan token // channel of scanned tokens.
+}
+
+// next returns the next rune in the input.
+func (l *lexer) next() (r rune) {
+	if l.pos >= len(l.input) {
+		l.width = 0
+		return eof
+	}
+	r, l.width = utf8.DecodeRuneInString(l.input[l.pos:])
+	l.pos += l.width
+	return r
+}
+
+// seek advances the pointer by n spaces.
+func (l *lexer) seek(n int) {
+	l.pos += n
+}
+
+// peek returns but does not consume the next rune in the input.
+func (l *lexer) peek() rune {
+	r := l.next()
+	l.backup()
+	return r
+}
+
+// backup steps back one rune. Can only be called once per call of next.
+func (l *lexer) backup() {
+	l.pos -= l.width
+}
+
+// buffer returns the string consumed by the lexer after the last emit.
+func (l *lexer) buffer() string {
+	return l.input[l.start:l.pos]
+}
+
+// emit passes an token back to the client.
+func (l *lexer) emit(t tokenType) {
+	l.tokens <- token{
+		t,
+		l.buffer(),
+		l.lineNum(),
+		l.columnNum(),
+	}
+	l.start = l.pos
+}
+
+// ignore skips over the pending input before this point.
+func (l *lexer) ignore() {
+	l.start = l.pos
+}
+
+// lineNum reports which line we're on. Doing it this way
+// means we don't have to worry about peek double counting.
+func (l *lexer) lineNum() int {
+	return 1 + strings.Count(l.input[:l.pos], "\n")
+}
+
+// columnNum reports the character of the current line we're on.
+func (l *lexer) columnNum() int {
+	if lf := strings.LastIndex(l.input[:l.pos], "\n"); lf != -1 {
+		return len(l.input[lf+1 : l.pos])
+	}
+	return len(l.input[:l.pos])
+}
+
+// error returns an error token and terminates the scan by passing
+// back a nil pointer that will be the next state, terminating l.token.
+func (l *lexer) errorf(format string, args ...interface{}) stateFn {
+	l.tokens <- token{
+		T_ERR,
+		fmt.Sprintf(format, args...),
+		l.lineNum(),
+		l.columnNum(),
+	}
+	return nil
+}
+
+// token returns the next token from the input.
+func (l *lexer) token() token {
+	for {
+		select {
+		case t := <-l.tokens:
+			return t
+		default:
+			l.state = l.state(l)
+		}
+	}
+}
+
+func (l *lexer) String() string {
+	w := bytes.NewBuffer(nil)
+	fmt.Fprintf(w, "Expression: %q\n", l.input)
+	fmt.Fprintf(w, "Index     : %d\n", l.pos)
+	fmt.Fprintf(w, "Current   : %q\n", l.input[l.pos])
+	fmt.Fprintf(w, "Buffer    : %q\n", l.input[l.start:l.pos])
+	return w.String()
+}
+
+// newLexer creates a new scanner for the input string.
+func newLexer(input string) *lexer {
+	l := &lexer{
+		input:  input,
+		tokens: make(chan token, 2),
+	}
+	l.state = stateInit
+	return l
+}
+
+// state functions.
+
+// stateInit is the initial state of the lexer.
+func stateInit(l *lexer) stateFn {
+start:
+	switch r := l.next(); {
+	case isWhitespace(r):
+		l.ignore()
+		goto start
+	case isNum(r):
+		return stateNumber
+	case isAlphanum(r):
+		return stateIdent
+	case isOperator(r):
+		return stateOp
+	case r == '\'':
+		return stateSQuote
+	case r == '"':
+		return stateDQuote
+	case r == '(':
+		l.emit(T_LEFT_PAREN)
+		goto start
+	case r == ')':
+		l.emit(T_RIGHT_PAREN)
+		goto start
+	}
+	return stateEnd
+}
+
+// stateEnd is the final state of the lexer. After this state is entered no more
+// tokens can be requested as it will result in a nil pointer dereference.
+func stateEnd(l *lexer) stateFn {
+	// Always end with EOF token. The parser will keep asking for tokens until
+	// an T_EOF or T_ERR token are encountered.
+	l.emit(T_EOF)
+
+	return nil
+}
+
+// stateIdent scans an indentifier from the input stream.
+func stateIdent(l *lexer) stateFn {
+loop:
+	for {
+		switch r := l.next(); {
+		case isAlphanum(r):
+		default:
+			break loop
+		}
+	}
+
+	l.backup()
+	l.emit(T_IDENTIFIER)
+
+	return stateInit
+}
+
+func stateOp(l *lexer) stateFn {
+	r := l.next()
+	for isOperator(r) {
+		r = l.next()
+	}
+
+	l.backup()
+
+	switch l.buffer() {
+	case "!":
+		l.emit(T_LOGICAL_NOT)
+	case "&&":
+		l.emit(T_LOGICAL_AND)
+	case "||":
+		l.emit(T_LOGICAL_OR)
+	case "==":
+		l.emit(T_IS_EQUAL)
+	case "!=":
+		l.emit(T_IS_NOT_EQUAL)
+	case ">":
+		l.emit(T_IS_GREATER)
+	case ">=":
+		l.emit(T_IS_GREATER_OR_EQUAL)
+	case "<":
+		l.emit(T_IS_SMALLER)
+	case "<=":
+		l.emit(T_IS_SMALLER_OR_EQUAL)
+	}
+
+	return stateInit
+}
+
+func stateSQuote(l *lexer) stateFn {
+	l.ignore()
+loop:
+	for {
+		switch l.next() {
+		case '\'':
+			l.backup()
+			l.emit(T_IDENTIFIER)
+			l.next()
+			l.ignore()
+			break loop
+		case eof:
+			return l.errorf("unexpected EOF")
+		}
+	}
+
+	return stateInit
+}
+
+func stateDQuote(l *lexer) stateFn {
+	l.ignore()
+loop:
+	for {
+		switch l.next() {
+		case '"':
+			l.backup()
+			l.emit(T_STRING)
+			l.next()
+			l.ignore()
+			break loop
+		case eof:
+			return l.errorf("unexpected EOF")
+		}
+	}
+
+	return stateInit
+}
+
+func stateNumber(l *lexer) stateFn {
+
+loop:
+	switch r := l.next(); {
+	case isNum(r) || r == '.':
+		goto loop
+	case r == eof:
+		break loop
+	default:
+		return l.errorf("unexpected character %#U", r)
+	}
+
+	l.emit(T_NUMBER)
+
+	return stateInit
+}
+
+// isWhitespace reports whether r is a space character.
+func isWhitespace(r rune) bool {
+	switch r {
+	case ' ', '\t', '\n', '\r':
+		return true
+	}
+	return false
+}
+
+// isNum reports whether r is a digit.
+func isNum(r rune) bool {
+	return unicode.IsDigit(r)
+}
+
+// isAlphanum reports whether r is an alphabetic, digit, or underscore.
+func isAlphanum(r rune) bool {
+	return r == '_' || r == '.' || unicode.IsLetter(r) || unicode.IsDigit(r)
+}
+
+// isOperator reports whether r is one of the predefined operators.
+func isOperator(r rune) bool {
+	return r == '=' || r == '!' || r == '>' || r == '<' || r == '&' || r == '|'
+}

--- a/parse/lex.go
+++ b/parse/lex.go
@@ -76,7 +76,7 @@ var tokenName = map[tokenType]string{
 func (i tokenType) String() string {
 	s := tokenName[i]
 	if s == "" {
-		return fmt.Sprintf("t_unknown_%d", int(i))
+		return fmt.Sprintf("T_UNKNOWN_%d", int(i))
 	}
 	return s
 }

--- a/parse/lex_test.go
+++ b/parse/lex_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2016 Alex Kalyvitis
+
+package parse
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestLexer(t *testing.T) {
+	for _, test := range []struct {
+		exp    string
+		tokens []token
+	}{
+		{
+			`foo > bar`,
+			[]token{
+				{Type: T_IDENTIFIER, Value: "foo"},
+				{Type: T_IS_GREATER, Value: ">"},
+				{Type: T_IDENTIFIER, Value: "bar"},
+				{Type: T_EOF},
+			},
+		},
+		{
+			`bar == 'baz'`,
+			[]token{
+				{Type: T_IDENTIFIER, Value: "bar"},
+				{Type: T_IS_EQUAL, Value: "=="},
+				{Type: T_IDENTIFIER, Value: "baz"},
+				{Type: T_EOF},
+			},
+		},
+		{
+			`(bar!="baz")&&foo==123.00`,
+			[]token{
+				{Type: T_LEFT_PAREN, Value: "("},
+				{Type: T_IDENTIFIER, Value: "bar"},
+				{Type: T_IS_NOT_EQUAL, Value: "!="},
+				{Type: T_STRING, Value: "baz"},
+				{Type: T_RIGHT_PAREN, Value: ")"},
+				{Type: T_LOGICAL_AND, Value: "&&"},
+				{Type: T_IDENTIFIER, Value: "foo"},
+				{Type: T_IS_EQUAL, Value: "=="},
+				{Type: T_NUMBER, Value: "123.00"},
+				{Type: T_EOF},
+			},
+		},
+	} {
+		var tokens []token
+		lexer := newLexer(test.exp)
+
+	loop:
+		for {
+			token := lexer.token()
+			tokens = append(tokens, token)
+
+			if token.Type == T_EOF || token.Type == T_ERR {
+				break loop
+			}
+		}
+
+		// t.Logf("%v\n", tokens)
+
+		assertEqual(t, test.tokens, tokens)
+	}
+}
+
+func assertEqual(t *testing.T, a, b interface{}) {
+	if !reflect.DeepEqual(a, b) {
+		t.Errorf("Failed asserting that items are equal.\n\twant: %s\n\thave: %s", a, b)
+	}
+}

--- a/parse/lex_test.go
+++ b/parse/lex_test.go
@@ -45,6 +45,14 @@ func TestLexer(t *testing.T) {
 				{Type: T_EOF},
 			},
 		},
+		{
+			`!true`,
+			[]token{
+				{Type: T_LOGICAL_NOT, Value: "!"},
+				{Type: T_BOOLEAN, Value: "true"},
+				{Type: T_EOF},
+			},
+		},
 	} {
 		var tokens []token
 		lexer := newLexer(test.exp)

--- a/parse/lex_test.go
+++ b/parse/lex_test.go
@@ -2,10 +2,7 @@
 
 package parse
 
-import (
-	"reflect"
-	"testing"
-)
+import "testing"
 
 func TestLexer(t *testing.T) {
 	for _, test := range []struct {
@@ -67,14 +64,19 @@ func TestLexer(t *testing.T) {
 			}
 		}
 
-		// t.Logf("%v\n", tokens)
+		if len(tokens) != len(test.tokens) {
+			t.Errorf("unexpected token stream length.\n\twant: %s\n\thave: %s", len(test.tokens), len(tokens))
+		}
 
-		assertEqual(t, test.tokens, tokens)
-	}
-}
+		for i := 0; i < len(tokens); i++ {
 
-func assertEqual(t *testing.T, a, b interface{}) {
-	if !reflect.DeepEqual(a, b) {
-		t.Errorf("Failed asserting that items are equal.\n\twant: %s\n\thave: %s", a, b)
+			if tokens[i].Type != test.tokens[i].Type {
+				t.Errorf("unexpected token type.\n\twant: %s\n\thave: %s", test.tokens[i].Type, tokens[i].Type)
+			}
+
+			if tokens[i].Value != test.tokens[i].Value {
+				t.Errorf("unexpected token value.\n\twant: %s\n\thave: %s", test.tokens[i].Value, tokens[i].Value)
+			}
+		}
 	}
 }

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -2,10 +2,7 @@
 
 package parse
 
-import (
-	"fmt"
-	"io"
-)
+import "fmt"
 
 type parser struct {
 	lexer *lexer
@@ -21,92 +18,6 @@ func (p *parser) read() token {
 		return r
 	}
 	return p.lexer.token()
-}
-
-// readn returns the next n tokens from the lexer and advances the cursor. If it
-// coundn't read all n tokens, for example if a T_EOF was returned by the
-// lexer, an error is returned and the returned slice will have all tokens read
-// until that point, including T_EOF.
-func (p *parser) readn(n int) ([]token, error) {
-	tokens := make([]token, 0, n) // make a slice capable of storing up to n tokens
-	for i := 0; i < n; i++ {
-		tokens = append(tokens, p.read())
-		if tokens[i].Type == T_EOF {
-			return tokens, io.EOF
-		}
-	}
-	return tokens, nil
-}
-
-// readt returns the tokens starting from the current position until the first
-// match of t. Similar to readn it will return an error if a T_EOF was
-// returned by the lexer before a match was made.
-func (p *parser) readt(t tokenType) ([]token, error) {
-	var tokens []token
-	for {
-		token := p.read()
-		tokens = append(tokens, token)
-		switch token.Type {
-		case T_EOF:
-			return tokens, io.EOF
-		case t:
-			return tokens, nil
-		default:
-			continue
-		}
-	}
-	return tokens, fmt.Errorf("token %q not found", t)
-}
-
-// peek returns the next token without advancing the cursor. Consecutive calls
-// of peek would result in the same token being retuned. To advance the cursor,
-// a read must be made.
-func (p *parser) peek() token {
-	if len(p.buf) > 0 {
-		return p.buf[0]
-	}
-	t := p.lexer.token()
-	p.buf = append(p.buf, t)
-	return t
-}
-
-// peekn returns the next n tokens without advancing the cursor.
-func (p *parser) peekn(n int) ([]token, error) {
-	if len(p.buf) > n {
-		return p.buf[:n], nil
-	}
-	for i := len(p.buf) - 1; i < n; i++ {
-		t := p.lexer.token()
-		p.buf = append(p.buf, t)
-		if t.Type == T_EOF {
-			return p.buf, io.EOF
-		}
-	}
-	return p.buf, nil
-}
-
-// peekt returns the tokens from the current postition until the first match of
-// t. it will not advance the cursor.
-func (p *parser) peekt(t tokenType) ([]token, error) {
-	for i := 0; i < len(p.buf); i++ {
-		switch p.buf[i].Type {
-		case t:
-			return p.buf[:i], nil
-		case T_EOF:
-			return p.buf[:i], io.EOF
-		}
-	}
-	for {
-		token := p.lexer.token()
-		p.buf = append(p.buf, token)
-		switch token.Type {
-		case t:
-			return p.buf, nil
-		case T_EOF:
-			break
-		}
-	}
-	return p.buf, io.EOF
 }
 
 // errorf creates a parsing error which describes the token currently being

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -1,0 +1,182 @@
+// Copyright (c) 2016 Alex Kalyvitis
+
+package parse
+
+import (
+	"fmt"
+	"io"
+)
+
+type parser struct {
+	lexer *lexer
+	buf   []token
+	ast   Exp
+}
+
+// read returns the next token from the lexer and advances the cursor. This
+// token will not be available by the parser after it has been read.
+func (p *parser) read() token {
+	if len(p.buf) > 0 {
+		r := p.buf[0]
+		p.buf = p.buf[1:]
+		return r
+	}
+	return p.lexer.token()
+}
+
+// readn returns the next n tokens from the lexer and advances the cursor. If it
+// coundn't read all n tokens, for example if a tokenEOF was returned by the
+// lexer, an error is returned and the returned slice will have all tokens read
+// until that point, including tokenEOF.
+func (p *parser) readn(n int) ([]token, error) {
+	tokens := make([]token, 0, n) // make a slice capable of storing up to n tokens
+	for i := 0; i < n; i++ {
+		tokens = append(tokens, p.read())
+		if tokens[i].typ == tokenEOF {
+			return tokens, io.EOF
+		}
+	}
+	return tokens, nil
+}
+
+// readt returns the tokens starting from the current position until the first
+// match of t. Similar to readn it will return an error if a tokenEOF was
+// returned by the lexer before a match was made.
+func (p *parser) readt(t tokenType) ([]token, error) {
+	var tokens []token
+	for {
+		token := p.read()
+		tokens = append(tokens, token)
+		switch token.typ {
+		case tokenEOF:
+			return tokens, io.EOF
+		case t:
+			return tokens, nil
+		default:
+			continue
+		}
+	}
+	return tokens, fmt.Errorf("token %q not found", t)
+}
+
+// peek returns the next token without advancing the cursor. Consecutive calls
+// of peek would result in the same token being retuned. To advance the cursor,
+// a read must be made.
+func (p *parser) peek() token {
+	if len(p.buf) > 0 {
+		return p.buf[0]
+	}
+	t := p.lexer.token()
+	p.buf = append(p.buf, t)
+	return t
+}
+
+// peekn returns the next n tokens without advancing the cursor.
+func (p *parser) peekn(n int) ([]token, error) {
+	if len(p.buf) > n {
+		return p.buf[:n], nil
+	}
+	for i := len(p.buf) - 1; i < n; i++ {
+		t := p.lexer.token()
+		p.buf = append(p.buf, t)
+		if t.typ == tokenEOF {
+			return p.buf, io.EOF
+		}
+	}
+	return p.buf, nil
+}
+
+// peekt returns the tokens from the current postition until the first match of
+// t. it will not advance the cursor.
+func (p *parser) peekt(t tokenType) ([]token, error) {
+	for i := 0; i < len(p.buf); i++ {
+		switch p.buf[i].typ {
+		case t:
+			return p.buf[:i], nil
+		case tokenEOF:
+			return p.buf[:i], io.EOF
+		}
+	}
+	for {
+		token := p.lexer.token()
+		p.buf = append(p.buf, token)
+		switch token.typ {
+		case t:
+			return p.buf, nil
+		case tokenEOF:
+			break
+		}
+	}
+	return p.buf, io.EOF
+}
+
+func (p *parser) errorf(t token, format string, v ...interface{}) error {
+	return fmt.Errorf("%d:%d syntax error: %s", t.line, t.col, fmt.Sprintf(format, v...))
+}
+
+// parse begins parsing based on tokens read from the lexer.
+func (p *parser) parse() (Exp, error) {
+	var exp Exp
+
+loop:
+	for {
+		token := p.read()
+		switch token.Type {
+		case T_EOF:
+			break loop
+		case T_ERR:
+			return nil, p.errorf(token, "%s", token.Value)
+		case T_IDENTIFIER:
+
+		case T_LEFT_PAREN:
+			t, err := p.readt(T_RIGHT_PAREN)
+			if err != nil {
+				return nil, p.errorf(t[len(t)-1], "%s", token.Value)
+			}
+			p = subParser(t)
+			e, err := p.parse()
+			if err != nil {
+				return nil, p.errorf(t[len(t)-1], "%s", token.Value)
+			}
+		}
+	}
+
+	// 	var nodes []node
+	// loop:
+	// 	for {
+	// 		token := p.read()
+	// 		switch token.typ {
+	// 		case tokenEOF:
+	// 			break loop
+	// 		case tokenError:
+	// 			return nil, p.errorf(token, "%s", token.val)
+	// 		case tokenText:
+	// 			nodes = append(nodes, textNode(token.val))
+	// 		case tokenLeftDelim:
+	// 			node, err := p.parseTag()
+	// 			if err != nil {
+	// 				return nodes, err
+	// 			}
+	// 			nodes = append(nodes, node)
+	// 		case tokenRawStart:
+	// 			node, err := p.parseRawTag()
+	// 			if err != nil {
+	// 				return nodes, err
+	// 			}
+	// 			nodes = append(nodes, node)
+	// 		case tokenSetDelim:
+	// 			nodes = append(nodes, new(delimNode))
+	// 		}
+	// 	}
+	return exp, nil
+}
+
+// newParser creates a new parser using the suppliad lexer.
+func newParser(l *lexer) *parser {
+	return &parser{lexer: l}
+}
+
+// subParser creates a new parser with a pre-defined token buffer.
+func subParser(b []token) *parser {
+	return &parser{buf: append(b, token{Type: T_EOF})}
+}

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -46,6 +46,30 @@ func TestParser(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		assertEqual(t, test.ast, ast)
+
+		assertTreeEqual(t, test.ast, ast)
 	}
+}
+
+func assertTreeEqual(t *testing.T, a, b *tree) {
+	t.Logf("\n\ta: %s\n\tb: %s", a, b)
+
+	if a == nil && b == nil {
+		return
+	}
+
+	if a == nil || b == nil {
+		t.Fatalf("unexpected nil tree.\n\twant: %s\n\thave: %s", a, b)
+	}
+
+	if a.value.Type != b.value.Type {
+		t.Fatalf("unexpected tree value type.\n\twant: %s\n\thave: %s", a.value, b.value)
+	}
+
+	if a.value.Value != b.value.Value {
+		t.Fatalf("unexpected tree value.\n\twant: %s\n\thave: %s", a.value.Value, b.value.Value)
+	}
+
+	assertTreeEqual(t, a.left, b.left)
+	assertTreeEqual(t, a.right, b.right)
 }

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2014 Alex Kalyvitis
+
+package parse
+
+// import (
+// 	"reflect"
+// 	"testing"
+// )
+//
+// func TestParser(t *testing.T) {
+// 	for _, test := range []struct {
+// 		template string
+// 		expected []node
+// 	}{
+// 		{
+// 			"{{#foo}}\n\t{{#foo}}hello nested{{/foo}}{{/foo}}",
+// 			[]node{
+// 				&sectionNode{"foo", false, []node{
+// 					textNode("\n\t"),
+// 					&sectionNode{"foo", false, []node{
+// 						textNode("hello nested"),
+// 					}},
+// 				}},
+// 			},
+// 		},
+// 		{
+// 			"\nfoo {{bar}} {{#alex}}\r\n\tbaz\n{{/alex}} {{!foo}}",
+// 			[]node{
+// 				textNode("\nfoo "),
+// 				&varNode{"bar", true},
+// 				textNode(" "),
+// 				&sectionNode{"alex", false, []node{
+// 					textNode("\r\n\tbaz\n"),
+// 				}},
+// 				textNode(" "),
+// 				commentNode("foo"),
+// 			},
+// 		},
+// 		{
+// 			"this will{{^foo}}not{{/foo}} be rendered",
+// 			[]node{
+// 				textNode("this will"),
+// 				&sectionNode{"foo", true, []node{
+// 					textNode("not"),
+// 				}},
+// 				textNode(" be rendered"),
+// 			},
+// 		},
+// 		{
+// 			"{{#list}}({{.}}){{/list}}",
+// 			[]node{
+// 				&sectionNode{"list", false, []node{
+// 					textNode("("),
+// 					&varNode{".", true},
+// 					textNode(")"),
+// 				}},
+// 			},
+// 		},
+// 	} {
+// 		parser := newParser(newLexer(test.template, "{{", "}}"))
+// 		elems, err := parser.parse()
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
+// 		for i, elem := range elems {
+// 			if !reflect.DeepEqual(elem, test.expected[i]) {
+// 				t.Errorf("elements are not equal %v != %v", elem, test.expected[i])
+// 			}
+// 		}
+// 	}
+// }

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -2,70 +2,50 @@
 
 package parse
 
-// import (
-// 	"reflect"
-// 	"testing"
-// )
-//
-// func TestParser(t *testing.T) {
-// 	for _, test := range []struct {
-// 		template string
-// 		expected []node
-// 	}{
-// 		{
-// 			"{{#foo}}\n\t{{#foo}}hello nested{{/foo}}{{/foo}}",
-// 			[]node{
-// 				&sectionNode{"foo", false, []node{
-// 					textNode("\n\t"),
-// 					&sectionNode{"foo", false, []node{
-// 						textNode("hello nested"),
-// 					}},
-// 				}},
-// 			},
-// 		},
-// 		{
-// 			"\nfoo {{bar}} {{#alex}}\r\n\tbaz\n{{/alex}} {{!foo}}",
-// 			[]node{
-// 				textNode("\nfoo "),
-// 				&varNode{"bar", true},
-// 				textNode(" "),
-// 				&sectionNode{"alex", false, []node{
-// 					textNode("\r\n\tbaz\n"),
-// 				}},
-// 				textNode(" "),
-// 				commentNode("foo"),
-// 			},
-// 		},
-// 		{
-// 			"this will{{^foo}}not{{/foo}} be rendered",
-// 			[]node{
-// 				textNode("this will"),
-// 				&sectionNode{"foo", true, []node{
-// 					textNode("not"),
-// 				}},
-// 				textNode(" be rendered"),
-// 			},
-// 		},
-// 		{
-// 			"{{#list}}({{.}}){{/list}}",
-// 			[]node{
-// 				&sectionNode{"list", false, []node{
-// 					textNode("("),
-// 					&varNode{".", true},
-// 					textNode(")"),
-// 				}},
-// 			},
-// 		},
-// 	} {
-// 		parser := newParser(newLexer(test.template, "{{", "}}"))
-// 		elems, err := parser.parse()
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		for i, elem := range elems {
-// 			if !reflect.DeepEqual(elem, test.expected[i]) {
-// 				t.Errorf("elements are not equal %v != %v", elem, test.expected[i])
-// 			}
-// 		}
-// 	}
-// }
+import "testing"
+
+func TestParser(t *testing.T) {
+	for _, test := range []struct {
+		exp string
+		ast *tree
+	}{
+		{
+			"(foo > bar)",
+			&tree{
+				value: token{Type: T_IS_GREATER, Value: ">"},
+				left: &tree{
+					value: token{Type: T_IDENTIFIER, Value: "foo"},
+				},
+				right: &tree{
+					value: token{Type: T_IDENTIFIER, Value: "bar"},
+				},
+			},
+		},
+		{
+			"((foo > bar) && true)",
+			&tree{
+				value: token{Type: T_LOGICAL_AND, Value: "&&"},
+				left: &tree{
+					value: token{Type: T_IS_GREATER, Value: ">"},
+					left:  &tree{value: token{Type: T_IDENTIFIER, Value: "foo"}},
+					right: &tree{value: token{Type: T_IDENTIFIER, Value: "bar"}},
+				},
+				right: &tree{value: token{Type: T_BOOLEAN, Value: "true"}},
+			},
+		},
+		{
+			"(foo > bar)",
+			&tree{
+				value: token{Type: T_IS_GREATER, Value: ">"},
+				left:  &tree{value: token{Type: T_IDENTIFIER, Value: "foo"}},
+				right: &tree{value: token{Type: T_IDENTIFIER, Value: "bar"}},
+			},
+		},
+	} {
+		ast, err := newParser(newLexer(test.exp)).parse()
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertEqual(t, test.ast, ast)
+	}
+}


### PR DESCRIPTION
This PR adds support for parsing expressions from text in the form of `(foo >= 123)`.

*The feature is fairly early stage so please use at your own risk.* That being said, I intend to improve it gradually by adding more expressions to match those already available.

Currently the supported operations are 

|Operator|Symbol|Data Type|
|-|-|-|
|`And`|`&&`||
|`Or`|`||`||
|`Equal`, `Eq`|`==`|`string`, `float64`|
|`NotEqual`, `Neq`|`!=`|`string`, `float64`|
|`GreaterThan `, `Gt`|`>`|`string`, `float64`|
|`GreaterThanEqual `, `Gte`|`>=`|`string`, `float64`|
|`LessThan `, `Lt`|`<`|`string`, `float64`|
|`LessThanEqual `, `Lte`|`<=`|`string`, `float64`|