### PR TITLE
correct parsing of complex expressions

### DIFF
--- a/parse/parse.go
+++ b/parse/parse.go
@@ -52,7 +52,6 @@ loop:
 			}
 		case T_LOGICAL_AND, T_LOGICAL_OR, T_LOGICAL_NOT, T_IS_EQUAL, T_IS_NOT_EQUAL, T_IS_GREATER, T_IS_GREATER_OR_EQUAL, T_IS_SMALLER, T_IS_SMALLER_OR_EQUAL:
 			if node.value.Type != T_ERR {
-				//new root
 				tree = newTree()
 				tree.left = node
 				tree.right = newTree()

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -51,10 +51,20 @@ loop:
 				break loop
 			}
 		case T_LOGICAL_AND, T_LOGICAL_OR, T_LOGICAL_NOT, T_IS_EQUAL, T_IS_NOT_EQUAL, T_IS_GREATER, T_IS_GREATER_OR_EQUAL, T_IS_SMALLER, T_IS_SMALLER_OR_EQUAL:
-			node.value = token
-			node.right = newTree()
-			stack.push(node)
-			node = node.right
+			if node.value.Type != T_ERR {
+				//new root
+				tree = newTree()
+				tree.left = node
+				tree.right = newTree()
+				tree.value = token
+				stack.push(tree)
+				node = tree.right
+			} else {
+				node.value = token
+				node.right = newTree()
+				stack.push(node)
+				node = node.right
+			}
 		case T_IDENTIFIER, T_NUMBER, T_STRING, T_BOOLEAN:
 			node.value = token
 			node, err = stack.pop()

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -10,6 +10,90 @@ func TestParser(t *testing.T) {
 		ast *tree
 	}{
 		{
+			"foo > bar",
+			&tree{
+				value: token{Type: T_IS_GREATER, Value: ">"},
+				left: &tree{
+					value: token{Type: T_IDENTIFIER, Value: "foo"},
+				},
+				right: &tree{
+					value: token{Type: T_IDENTIFIER, Value: "bar"},
+				},
+			},
+		},
+		{
+			"((f > 1) && (f < 3)) && ((b > 1) && (b < 3))",
+			&tree{
+				value: token{Type: T_LOGICAL_AND, Value: "&&"},
+				left: &tree{
+					value: token{Type: T_LOGICAL_AND, Value: "&&"},
+					left: &tree{
+						value: token{Type: T_IS_GREATER, Value: ">"},
+						left: &tree{
+							value: token{Type: T_IDENTIFIER, Value: "f"},
+						},
+						right: &tree{
+							value: token{Type: T_NUMBER, Value: "1"},
+						},
+					},
+					right: &tree{
+						value: token{Type: T_IS_SMALLER, Value: "<"},
+						left: &tree{
+							value: token{Type: T_IDENTIFIER, Value: "f"},
+						},
+						right: &tree{
+							value: token{Type: T_NUMBER, Value: "3"},
+						},
+					},
+				},
+				right: &tree{
+					value: token{Type: T_LOGICAL_AND, Value: "&&"},
+					left: &tree{
+						value: token{Type: T_IS_GREATER, Value: ">"},
+						left: &tree{
+							value: token{Type: T_IDENTIFIER, Value: "b"},
+						},
+						right: &tree{
+							value: token{Type: T_NUMBER, Value: "1"},
+						},
+					},
+					right: &tree{
+						value: token{Type: T_IS_SMALLER, Value: "<"},
+						left: &tree{
+							value: token{Type: T_IDENTIFIER, Value: "b"},
+						},
+						right: &tree{
+							value: token{Type: T_NUMBER, Value: "3"},
+						},
+					},
+				},
+			},
+		},
+		{
+			"((f > 1) && (f < 3))",
+			&tree{
+				value: token{Type: T_LOGICAL_AND, Value: "&&"},
+				left: &tree{
+					value: token{Type: T_IS_GREATER, Value: ">"},
+					left: &tree{
+						value: token{Type: T_IDENTIFIER, Value: "f"},
+					},
+					right: &tree{
+						value: token{Type: T_NUMBER, Value: "1"},
+					},
+				},
+				right: &tree{
+					value: token{Type: T_IS_SMALLER, Value: "<"},
+					left: &tree{
+						value: token{Type: T_IDENTIFIER, Value: "f"},
+					},
+					right: &tree{
+						value: token{Type: T_NUMBER, Value: "3"},
+					},
+				},
+			},
+		},
+		{
 			"(foo > bar)",
 			&tree{
 				value: token{Type: T_IS_GREATER, Value: ">"},


### PR DESCRIPTION
example: ((f > 1) && (f < 3)) && ((b > 1) && (b < 3))
or: foo > bar
brackets are optional